### PR TITLE
Replace obsolete AC_TRY_FOO with AC_FOO_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -269,18 +269,14 @@ if test "$PHP_MEMCACHED" != "no"; then
       if test "$ac_cv_have_memc_sasl_h" = "yes"; then
 
         AC_CACHE_CHECK([whether libmemcached supports sasl], ac_cv_memc_sasl_support, [
-          AC_TRY_COMPILE(
-            [ #include <libmemcached/memcached.h> ],
-            [ 
+          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <libmemcached/memcached.h>]], [[
             #if LIBMEMCACHED_WITH_SASL_SUPPORT
               /* yes */
             #else
             #  error "no sasl support"
-            #endif
-            ],
-            [ ac_cv_memc_sasl_support="yes" ],
-            [ ac_cv_memc_sasl_support="no" ]
-          )
+            #endif]])],
+            [ac_cv_memc_sasl_support="yes"],
+            [ac_cv_memc_sasl_support="no"])
         ])
 
         if test "$ac_cv_memc_sasl_support" = "yes"; then
@@ -303,12 +299,11 @@ if test "$PHP_MEMCACHED" != "no"; then
     LIBS="$LIBS $PHP_LIBMEMCACHED_LIBS"
 
     AC_CACHE_CHECK([whether memcached_exist is defined], ac_cv_have_memcached_exist, [
-      AC_TRY_LINK(
-        [ #include <libmemcached/memcached.h> ],
-        [ memcached_exist (NULL, NULL, 0); ],
-        [ ac_cv_have_memcached_exist="yes" ],
-        [ ac_cv_have_memcached_exist="no" ]
-      )
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([[#include <libmemcached/memcached.h>]],
+          [[memcached_exist (NULL, NULL, 0);]])],
+        [ac_cv_have_memcached_exist="yes"],
+        [ac_cv_have_memcached_exist="no"])
     ])
 
     CFLAGS="$ORIG_CFLAGS"
@@ -340,14 +335,12 @@ if test "$PHP_MEMCACHED" != "no"; then
       AC_MSG_RESULT([enabled])
 
       AC_CACHE_CHECK([whether libmemcachedprotocol is usable], ac_cv_have_libmemcachedprotocol, [
-        AC_TRY_COMPILE(
-          [ #include <libmemcachedprotocol-0.0/handler.h> ],
-          [ memcached_binary_protocol_callback_st s_test_impl;
-            s_test_impl.interface.v1.delete_object = 0;
-          ],
-          [ ac_cv_have_libmemcachedprotocol="yes" ],
-          [ ac_cv_have_libmemcachedprotocol="no" ]
-        )
+        AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([[#include <libmemcachedprotocol-0.0/handler.h>]],
+            [[memcached_binary_protocol_callback_st s_test_impl;
+            s_test_impl.interface.v1.delete_object = 0;]])],
+          [ac_cv_have_libmemcachedprotocol="yes"],
+          [ac_cv_have_libmemcachedprotocol="no"])
       ])
 
       if test "$ac_cv_have_libmemcachedprotocol" != "yes"; then


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the AC_TRY_COMPILE and AC_TRY_LINK in 2000 and since Autoconf 2.50: http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current AC_FOO_IFELSE instead.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3. PHP versions from 5.4 to 7.1 require Autoconf 2.59+ and PHP 7.2+ require Autoconf 2.64+.

This patch was created with the help of autoupdate script.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf

Thanks.