### PR TITLE
Add configure.ac to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config.nice
 config.status
 config.sub
 configure
+configure.ac
 configure.in
 conftest
 conftest.c


### PR DESCRIPTION
The configure.ac file is automatically generated during phpize step. Prior to PHP 7.2, the prehistoric configure.in is generated. Since PHP 7.2 this file is named configure.ac