### PR TITLE
Sync with upstream memcached v3.1.5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 memcached extension changelog
 
+Version 3.1.5 (2019-12-03)
+--------------------------
+
+	* Fix build with PHP 7.4 release due to ulong typedef removal (#445)
+
+Version 3.1.4 (2019-10-06)
+--------------------------
+
+	* Test on PHP 7.4 as well as 8.0 (#440)
+	* Fix segfault for unknown memcached flags (#431)
+	* Update documented defaults for sess_lock_retries( #432)
+	* Remove stray instances of the TSRMLS_CC macro for PHP 8 compatibility (#444)
+
 Version 3.1.3 (2018-12-24)
 --------------------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -88,7 +88,7 @@ Dependencies
 ------------
 
 php-memcached 3.x:
-* Supports PHP 7.0 - 7.3.
+* Supports PHP 7.0 - 7.4.
 * Requires libmemcached 1.x or higher.
 * Optionally supports igbinary 2.0 or higher.
 * Optionally supports msgpack 2.0 or higher.

--- a/package.xml
+++ b/package.xml
@@ -27,9 +27,9 @@ http://pear.php.net/dtd/package-2.0.xsd">
   <email>aaron@serendipity.cx</email>
   <active>yes</active>
  </lead>
- <date>2018-12-24</date>
+ <date>2019-12-03</date>
  <version>
-  <release>3.1.3</release>
+  <release>3.1.5</release>
   <api>3.0.0</api>
  </version>
  <stability>
@@ -38,13 +38,13 @@ http://pear.php.net/dtd/package-2.0.xsd">
  </stability>
  <license uri="http://www.php.net/license">PHP</license>
  <notes>
-PHP 7.0 - 7.1 - 7.2 - 7.3 release of memcached extension. Note that support for
+PHP 7.0 - 7.1 - 7.2 - 7.3 - 7.4 release of memcached extension. Note that support for
 libmemcached 0.x series has been discontinued and the oldest actively tested
 version is 1.0.8. It is highly recommended to use version 1.0.18 of
 libmemcached.
 
 Fixes
-  * Fix --disable-memcached-session by ifdef-ing session INI handler callbacks (#396, #420)
+ * Fix build with PHP 7.4 release due to ulong typedef removal (#445)
  </notes>
  <contents>
   <dir name="/">
@@ -203,6 +203,49 @@ Fixes
   <configureoption name="enable-memcached-session"  prompt="enable sessions"            default="yes"/>
  </extsrcrelease>
  <changelog>
+    <release>
+      <stability>
+        <release>stable</release>
+        <api>stable</api>
+      </stability>
+      <version>
+        <release>3.1.4</release>
+        <api>3.0.0</api>
+      </version>
+      <date>2019-10-06</date>
+      <notes>
+PHP 7.0 - 7.1 - 7.2 - 7.3 - 7.4 release of memcached extension. Note that support for
+libmemcached 0.x series has been discontinued and the oldest actively tested
+version is 1.0.8. It is highly recommended to use version 1.0.18 of
+libmemcached.
+
+Fixes
+  * Test on PHP 7.4 as well as 8.0 (#440)
+  * Fix segfault for unknown memcached flags (#431)
+  * Update documented defaults for sess_lock_retries (#432)
+  * Remove stray instances of the TSRMLS_CC macro for PHP 8 compatibility (#444)
+      </notes>
+    </release>
+    <release>
+      <stability>
+        <release>stable</release>
+        <api>stable</api>
+      </stability>
+      <version>
+        <release>3.1.3</release>
+        <api>3.0.0</api>
+      </version>
+      <date>2018-12-22</date>
+      <notes>
+PHP 7.0 - 7.1 - 7.2 - 7.3 release of memcached extension. Note that support for
+libmemcached 0.x series has been discontinued and the oldest actively tested
+version is 1.0.8. It is highly recommended to use version 1.0.18 of
+libmemcached.
+
+Fixes
+  * Fix --disable-memcached-session by ifdef-ing session INI handler callbacks (#396, #420)
+      </notes>
+    </release>
     <release>
       <stability>
         <release>stable</release>

--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3234,7 +3234,7 @@ static PHP_METHOD(Memcached, setOptions)
 	zval *options;
 	zend_bool ok = 1;
 	zend_string *key;
-	ulong key_index;
+	zend_ulong key_index;
 	zval *value;
 
 	MEMC_METHOD_INIT_VARS;

--- a/php_memcached.h
+++ b/php_memcached.h
@@ -30,7 +30,7 @@
 # include "config.h"
 #endif
 
-#define PHP_MEMCACHED_VERSION "3.1.3"
+#define PHP_MEMCACHED_VERSION "3.1.5"
 
 #if defined(PHP_WIN32) && defined(MEMCACHED_EXPORTS)
 #define PHP_MEMCACHED_API __declspec(dllexport)

--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -445,7 +445,7 @@ PS_READ_FUNC(memcached)
 		*val = ZSTR_EMPTY_ALLOC();
 		return SUCCESS;
 	} else {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
+		php_error_docref(NULL, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
 		return FAILURE;
 	}
 }
@@ -475,7 +475,7 @@ PS_WRITE_FUNC(memcached)
 		if (memcached_set(memc, key->val, key->len, val->val, val->len, expiration, 0) == MEMCACHED_SUCCESS) {
 			return SUCCESS;
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
+			php_error_docref(NULL, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
 		}
 	} while (--retries > 0);
 


### PR DESCRIPTION
*Description of changes:*
Merge in changes from upstream (https://github.com/php-memcached-dev/php-memcached) version 3.1.5. Includes PHP 7.4 support (as people are longing for in issue #32).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
