### PR TITLE
Fixed README minor inconsistencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,7 +76,7 @@ Note: If you want to enable igbinary support, checkout, compile, and install the
 
 Note: you can statically link the libmemcached library into the PHP binary so it can be ported across various Linux platforms. To do that, run the following command before "make":
 
-> sed -i "s#-lmemcached#<libmemcached build directory>\/lib\/libmemcached.a -lcrypt -lpthread -lm -lstdc++ -lsasl2#" Makefile
+> sed -i "s#-lmemcached -lmemcachedutil#&lt;libmemcached build directory&gt;\/lib\/libmemcached.a &lt;libmemcached build directory&gt;\/lib\/libmemcachedutil.a -lcrypt -lpthread -lm -lstdc++ -lsasl2#" Makefile
 
 # Resources
 ---------


### PR DESCRIPTION
- '<', '>' disappear in MD
- libmemcachedutil must be included in static linking

*Issue #, if available: No issue linked  

*Description of changes: I have compiled the memcached.so for PHP 7.4 and I have seen two minor inconsistencies in README when compiling static linking with the libmemcached.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
