### PR TITLE
fix for php8

### DIFF
--- a/php_memcached_session.c
+++ b/php_memcached_session.c
@@ -445,7 +445,7 @@ PS_READ_FUNC(memcached)
 		*val = ZSTR_EMPTY_ALLOC();
 		return SUCCESS;
 	} else {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
+		php_error_docref(NULL, E_WARNING, "error getting session from memcached: %s", memcached_last_error_message(memc));
 		return FAILURE;
 	}
 }
@@ -475,7 +475,7 @@ PS_WRITE_FUNC(memcached)
 		if (memcached_set(memc, key->val, key->len, val->val, val->len, expiration, 0) == MEMCACHED_SUCCESS) {
 			return SUCCESS;
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
+			php_error_docref(NULL, E_WARNING, "error saving session to memcached: %s", memcached_last_error_message(memc));
 		}
 	} while (--retries > 0);
 


### PR DESCRIPTION
in the php7 branch, I was getting "error: too few arguments to function 'php_error_docref'" when building for php8, removed these references to TSRMLS_CC and the build now works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
