### PR TITLE
Return the server ip if it's available as part of getServerList

### DIFF
--- a/php_memcached.c
+++ b/php_memcached.c
@@ -3526,6 +3526,11 @@ memcached_return s_server_cursor_list_servers_cb(const memcached_st *ptr, php_me
 
 	array_init(&array);
 	add_assoc_string(&array, "host", (char*)memcached_server_name(instance));
+
+	if (has_memcached_instance_ipaddress(instance)) {
+ 		add_assoc_string(&array, "ipaddress", (char*)memcached_server_ipaddress(instance));
+ 	}
+
 	add_assoc_long(&array,   "port", memcached_server_port(instance));
 	add_assoc_string(&array, "type", (char*)memcached_server_type(instance));
 	/*


### PR DESCRIPTION
*Description of changes:*
Return the server ip if it's available as part of getServerList

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Depends on https://github.com/awslabs/aws-elasticache-cluster-client-libmemcached/pull/18
